### PR TITLE
update/diaryStatistics: 우리 아이 통계 페이지 연결

### DIFF
--- a/src/main/java/com/scit/iLog/config/SecurityConfig.java
+++ b/src/main/java/com/scit/iLog/config/SecurityConfig.java
@@ -32,6 +32,8 @@ public class SecurityConfig {
                                 "/board/boardDetail",
                                 "/board/download",
                                 "/reply/replyInsert",
+                                "/children/diaryStatistics",
+                                "/children/diaries",
                                 "/js/**",
                                 "/css/**",
                                 "/images/**")

--- a/src/main/java/com/scit/iLog/controller/DiaryController.java
+++ b/src/main/java/com/scit/iLog/controller/DiaryController.java
@@ -1,4 +1,25 @@
 package com.scit.iLog.controller;
 
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+
+import lombok.RequiredArgsConstructor;
+
+@Controller
+@RequiredArgsConstructor
 public class DiaryController {
+	
+	// 우리 아이 일기 통계로 보기 로 이동하기! = 우리 아이 일기장 버튼
+    @GetMapping("/children/diaryStatistics")
+    public String diaryStatistics() {
+        return "/children/diaryStatistics";
+    }
+	
+	// 일기 목록 자세히 보기 로 이동하기!
+    @GetMapping("/children/diaries")
+    public String diaries() {
+        return "/children/diaries";
+    }
+    
+    
 }

--- a/src/main/java/com/scit/iLog/controller/MainController.java
+++ b/src/main/java/com/scit/iLog/controller/MainController.java
@@ -16,4 +16,5 @@ public class MainController {
         return "guides";
     }
     
+    
 }

--- a/src/main/resources/templates/children/dashboard.html
+++ b/src/main/resources/templates/children/dashboard.html
@@ -6,10 +6,13 @@
 >
 <head>
     <meta charset="UTF-8">
-    <title>Title</title>
+    <title>Dashboard</title>
     <script src="/js/jquery-3.7.1.min.js"></script>
 </head>
 <body>
 
+	<!-- 우리 아이 일기 통계로 바로가기 -->
+	<p><a th:href="@{/children/diaryStatistics}">우리 아이 일기장</a></p>
+	
 </body>
 </html>

--- a/src/main/resources/templates/children/diaryStatistics.html
+++ b/src/main/resources/templates/children/diaryStatistics.html
@@ -6,10 +6,31 @@
 >
 <head>
     <meta charset="UTF-8">
-    <title>Title</title>
+    <title>우리 아이 일기 통계로 보기</title>
     <script src="/js/jquery-3.7.1.min.js"></script>
 </head>
 <body>
-
+	<h2>우리 아이 일기 통계로 보기</h2>
+	
+	<!-- 틀 미리보기! 확정X -->
+	<div>
+        <h2>저장된 사용자 정보</h2>
+        <table border="1">
+            <tr>
+                <th>항목</th>
+                <th>값</th>
+            </tr>
+            <tr>
+                <td><strong>이름</strong></td>
+                <td id="savedUsername"></td>
+            </tr>
+            <tr>
+                <td><strong>나이</strong></td>
+                <td id="savedAge"></td>
+            </tr>
+        </table>
+        <p><a th:href="@{/children/diaries}">일기 목록 자세히 보기</a></p>
+    </div>
+    
 </body>
 </html>


### PR DESCRIPTION
대시보드페이지에서 우리 아이 일기장을 클릭 시 우리 아이 통계 페이지로
연결되도록 구현되도록 경로 맵핑 + 우리 아이 통계 페이지에서 일기 목록
자세히 보기를 클릭 시 diaries.html로 이동되도록 경로 맵핑 +
diaryController에 getmapping 들 추가
- close #16 