### PR TITLE
아이 일기장 목록 페이지 : 아이 일기장 목록으로 넘어가는 페이지 요청

### DIFF
--- a/src/main/java/com/scit/iLog/config/SecurityConfig.java
+++ b/src/main/java/com/scit/iLog/config/SecurityConfig.java
@@ -29,6 +29,7 @@ public class SecurityConfig {
                                 "/user/idCheck",
                                 "/user/login",
                                 "/board/boardList",
+                                "/children/diaries",
                                 "/board/boardDetail",
                                 "/board/download",
                                 "/reply/replyInsert",

--- a/src/main/java/com/scit/iLog/controller/DiaryController.java
+++ b/src/main/java/com/scit/iLog/controller/DiaryController.java
@@ -1,4 +1,18 @@
 package com.scit.iLog.controller;
 
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Controller
+@RequestMapping("/children")
+@Slf4j
 public class DiaryController {
+
+    //일기장 목록 페이지 요청
+    @GetMapping("/diaries")
+    public String selectAll(){
+        return "/children/diaries";
+    }
 }

--- a/src/main/resources/templates/children/diaries.html
+++ b/src/main/resources/templates/children/diaries.html
@@ -11,5 +11,26 @@
 </head>
 <body>
 
+<h2>김승현군 일기장 목록 페이지</h2>
+
+<a href="#">일기 쓰기</a>
+
+<div id="list">
+    <label>번호</label>&nbsp;
+    <label>등록일</label>&nbsp;
+    <label>제목</label>&nbsp;
+</div>
+<hr>
+<div id="result">
+    <table>
+        <tr>
+            <th class="w50">번호</th>
+            <th class="w200 update">등록일</th>
+            <th class="w200 title">제목</th>
+            <th class="w50 delBtns">삭제</th>
+        </tr>
+    </table>
+</div>
+
 </body>
 </html>


### PR DESCRIPTION
우리 아이 일기장 목록 페이지로 넘어가는 컨트롤러 메서드 추가,
diaries 페이지 내용 간단히 적었음(상세페이지 구현은 나중에),
Security에서 /children/diaries 경로 추가했습니다.

- close #17 