### PR TITLE
도메인 엔티티 추가: 테이블 설계에 따른 도메인 엔티티를 추가합니다.

### DIFF
--- a/src/main/java/com/scit/iLog/domain/AnalysisResult.java
+++ b/src/main/java/com/scit/iLog/domain/AnalysisResult.java
@@ -1,0 +1,35 @@
+package com.scit.iLog.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@Table(name = "analysis_result")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class AnalysisResult extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "analysis_id")
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "diary_id")
+    private ChildDiary diary;
+
+    @Column(name = "emotion_score")
+    private double emotionScore;
+
+    @Column(name = "analysis_result")
+    private String analysisResult;
+
+    @Column(name = "solution")
+    private String solution;
+}

--- a/src/main/java/com/scit/iLog/domain/BaseEntity.java
+++ b/src/main/java/com/scit/iLog/domain/BaseEntity.java
@@ -1,0 +1,28 @@
+package com.scit.iLog.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedBy;
+import org.springframework.data.annotation.LastModifiedBy;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import org.springframework.format.annotation.DateTimeFormat;
+
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class BaseEntity extends BaseTimeEntity {
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    @CreatedBy
+    @Column(updatable = false, nullable = false)
+    protected String createdBy;
+
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    @LastModifiedBy
+    protected String modifiedBy;
+}

--- a/src/main/java/com/scit/iLog/domain/BaseTimeEntity.java
+++ b/src/main/java/com/scit/iLog/domain/BaseTimeEntity.java
@@ -1,0 +1,27 @@
+package com.scit.iLog.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class BaseTimeEntity {
+    @CreatedDate
+    @Column(name = "created_at",updatable = false,nullable = false)
+    protected LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "modified_at")
+    protected LocalDateTime modifiedAt;
+}

--- a/src/main/java/com/scit/iLog/domain/Child.java
+++ b/src/main/java/com/scit/iLog/domain/Child.java
@@ -1,0 +1,43 @@
+package com.scit.iLog.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@Table(name = "child")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Child extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "child_id")
+    private Long id;
+
+    @Column(name = "name")
+    private String name;
+
+    @Column(name = "birth_date")
+    private LocalDateTime birthDate;
+
+    @Column(name = "weight")
+    private double weight;
+
+    @Column(name = "height")
+    private double height;
+
+    @Column(name = "note")
+    private String note;
+
+    @Enumerated(EnumType.STRING)
+    private Gender gender;
+
+    @OneToMany(mappedBy = "child")
+    private List<ChildDiary> diaries = new ArrayList<>();
+}

--- a/src/main/java/com/scit/iLog/domain/ChildDiary.java
+++ b/src/main/java/com/scit/iLog/domain/ChildDiary.java
@@ -1,0 +1,29 @@
+package com.scit.iLog.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@Table(name = "child_diary")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ChildDiary extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "diary_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "child_id")
+    private Child child;
+
+    @Column(name = "content")
+    private String content;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member author;
+}

--- a/src/main/java/com/scit/iLog/domain/ChildMedia.java
+++ b/src/main/java/com/scit/iLog/domain/ChildMedia.java
@@ -1,0 +1,30 @@
+package com.scit.iLog.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@Table(name = "child_media")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ChildMedia {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "child_media_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "child_id")
+    private Child child;
+
+    @Column(name = "analysis_result")
+    private String analysisResult;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "type")
+    private ChildMediaType type;
+
+}

--- a/src/main/java/com/scit/iLog/domain/ChildMediaType.java
+++ b/src/main/java/com/scit/iLog/domain/ChildMediaType.java
@@ -1,0 +1,11 @@
+package com.scit.iLog.domain;
+
+public enum ChildMediaType {
+    DRAWING("그림"),
+    PHOTO("사진"),
+    VOICE("음성"),
+    WRITING("글");
+
+    ChildMediaType(String typeKr) {
+    }
+}

--- a/src/main/java/com/scit/iLog/domain/Gender.java
+++ b/src/main/java/com/scit/iLog/domain/Gender.java
@@ -1,0 +1,8 @@
+package com.scit.iLog.domain;
+
+public enum Gender {
+    MAN("남"), WOMAN("여"), NONE("선택안함");
+
+    Gender(String genderKr) {
+    }
+}

--- a/src/main/java/com/scit/iLog/domain/Guide.java
+++ b/src/main/java/com/scit/iLog/domain/Guide.java
@@ -1,0 +1,28 @@
+package com.scit.iLog.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@Table(name = "guide")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Guide extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "guide_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member author;
+
+    @Column(name = "title")
+    private String title;
+
+    @Column(name = "content")
+    private String content;
+}

--- a/src/main/java/com/scit/iLog/domain/HealthSurvey.java
+++ b/src/main/java/com/scit/iLog/domain/HealthSurvey.java
@@ -1,0 +1,32 @@
+package com.scit.iLog.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import static jakarta.persistence.FetchType.LAZY;
+
+@Entity
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@Table(name = "health_survey")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class HealthSurvey extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "survey_id")
+    private Long id;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "child_id")
+    private Child child;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "member_id")
+    private Member author;
+
+    @Column(name = "survey_data")
+    private String data;
+
+}

--- a/src/main/java/com/scit/iLog/domain/Member.java
+++ b/src/main/java/com/scit/iLog/domain/Member.java
@@ -1,0 +1,30 @@
+package com.scit.iLog.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@Table(name = "member")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Member extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "member_id")
+    private Long id;
+
+    @Column(name = "name")
+    private String name;
+
+    @Column(name = "password")
+    private String password;
+
+    @Column(name = "email")
+    private String email;
+
+    @Enumerated(EnumType.STRING)
+    private MemberRole role;
+}

--- a/src/main/java/com/scit/iLog/domain/MemberRole.java
+++ b/src/main/java/com/scit/iLog/domain/MemberRole.java
@@ -1,0 +1,9 @@
+package com.scit.iLog.domain;
+
+public enum MemberRole {
+    ADMIN("관리지"),
+    USER("회원");
+
+    MemberRole(String roleNameKr) {
+    }
+}

--- a/src/main/java/com/scit/iLog/domain/QAndA.java
+++ b/src/main/java/com/scit/iLog/domain/QAndA.java
@@ -1,0 +1,34 @@
+package com.scit.iLog.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@Table(name = "qna")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class QAndA extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "qna_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member author;
+
+    @Column(name = "title")
+    private String title;
+
+    @Column(name = "question")
+    private String question;
+
+    @Column(name = "answer")
+    private String answer;
+
+    @Enumerated(EnumType.STRING)
+    private QuestionCategory category;
+}

--- a/src/main/java/com/scit/iLog/domain/QuestionCategory.java
+++ b/src/main/java/com/scit/iLog/domain/QuestionCategory.java
@@ -1,0 +1,10 @@
+package com.scit.iLog.domain;
+
+public enum QuestionCategory {
+    USAGE("이용방법"),
+    PRIVACY("개인정보보안"),
+    GENERAL("기타");
+
+    QuestionCategory(String category) {
+    }
+}

--- a/src/main/java/com/scit/iLog/domain/RelationShip.java
+++ b/src/main/java/com/scit/iLog/domain/RelationShip.java
@@ -1,0 +1,30 @@
+package com.scit.iLog.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@Table(name = "relationship")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RelationShip extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "relationship_id")
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "guardian_id")
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "relationShip")
+    private Child child;
+
+    @Enumerated(EnumType.STRING)
+    private RelationType relationType;
+
+}

--- a/src/main/java/com/scit/iLog/domain/RelationType.java
+++ b/src/main/java/com/scit/iLog/domain/RelationType.java
@@ -1,0 +1,4 @@
+package com.scit.iLog.domain;
+
+public enum RelationType {
+}


### PR DESCRIPTION
서비스 기획 및 ERDiagram에 따른 테이블에 대응하는
도메인 엔티티 클래스를 추가합니다.
유효성 검증 로직 및 더 구체적인  도메인 로직이 필요합니다.
- close #26 