### PR TITLE
대시보드 컨트롤러 메서드 이름 수정: 대시보드 컨트롤러의 메서드 이름 수정, 클래스, 메서드 주석 추가

### DIFF
--- a/src/main/java/com/scit/iLog/controller/DashboardController.java
+++ b/src/main/java/com/scit/iLog/controller/DashboardController.java
@@ -3,17 +3,30 @@ package com.scit.iLog.controller;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 
+/**
+ * 사용자의 대시보드 페이지 조회에 필요한 요청을 처리하는 컨트롤러.
+ * 대시보드는
+ * 부모 권한을 가진 사용자가 조회하는 대시보드,
+ * 선생님 권한을 가진 사용자가 조회하는 대시보드
+ * 로 구분되어 있습니다.
+ * 각 대시보드는 서로 다른 목적을 가지며,
+ * 권한에 따라 조회할 수 있는 정보의 종류가 다릅니다.
+ */
 @Controller
 public class DashboardController {
+    /**
+     * @return 부모 권한을 가진 사용자만 볼 수 있는 대시보드 페이지 템플릿의 경로를 반환합니다.
+     */
     @GetMapping("/parentDashboard")
-    public String parentDashboard() {
-    	
+    public String handleGetParentDashboardView() {
         return "dashboard/parentView";
     }
 
+    /**
+     * @return 선생님 권한을 가진 사용자만 볼 수 있는 대시보드 페이지의 템플릿의 경로를 반환합니다.
+     */
     @GetMapping("/teacherDashboard")
-    public String teacherDashboard() {
-
+    public String handleGetTeacherDashboardView() {
     	return "dashboard/teacherView";
     }
 }

--- a/src/main/java/com/scit/iLog/controller/StatisticsController.java
+++ b/src/main/java/com/scit/iLog/controller/StatisticsController.java
@@ -2,6 +2,9 @@ package com.scit.iLog.controller;
 
 import org.springframework.stereotype.Controller;
 
+/**
+ *
+ */
 @Controller
 public class StatisticsController {
 


### PR DESCRIPTION
컨트롤러의 역할과 메서드의 역할을 명확히하고,
소스코드의 이해도를 높이기 위해 메서드 이름을 통일하고,
주석을 추가합니다.
closes #65 