### PR TITLE
로그인시 대시보드 바로가기 기능 수정: 사용자 경험 변경에 따른 로그인 유지시 대시보드 바로접속 기능을 수정합니다.

### DIFF
--- a/src/main/java/com/scit/iLog/controller/DashboardController.java
+++ b/src/main/java/com/scit/iLog/controller/DashboardController.java
@@ -30,6 +30,19 @@ import static com.scit.iLog.config.SecurityConfig.MemberDetails;
 @RequestMapping("/dashboard")
 public class DashboardController {
     private final ChildService childService;
+
+    /**
+     * D-1,D-2
+     * @return 부모 권한을 가진 사용자만 볼 수 있는 대시보드 페이지 템플릿의 경로를 반환합니다.
+     */
+    @GetMapping({"","/"})
+    public String handleGetDashboardView(
+            @AuthenticationPrincipal MemberDetails memberDetails
+    ) {
+        return memberDetails.getRelationType() == RelationType.GUARDIAN ?
+                "redirect:/dashboard/guardian" : "redirect:/dashboard/teacher";
+    }
+
     /*
         D-1
      */


### PR DESCRIPTION
사용자는 로그인을 한 상태라도, 랜딩페이지를 확인하고 싶을 수 있으므로,
랜딩페이지 접속시 대시보드 바로가기 기능은 제거합니다.